### PR TITLE
Fix/spv CVE 2012 2459

### DIFF
--- a/electrum/verifier.py
+++ b/electrum/verifier.py
@@ -43,6 +43,7 @@ class MerkleVerificationFailure(Exception): pass
 class MissingBlockHeader(MerkleVerificationFailure): pass
 class MerkleRootMismatch(MerkleVerificationFailure): pass
 class InnerNodeOfSpvProofIsValidTx(MerkleVerificationFailure): pass
+class LeftSiblingDuplicate(MerkleVerificationFailure): pass
 
 
 class SPV(NetworkJobOnDefaultServer):
@@ -149,11 +150,16 @@ class SPV(NetworkJobOnDefaultServer):
         if leaf_pos_in_tree < 0:
             raise MerkleVerificationFailure('leaf_pos_in_tree must be non-negative')
         index = leaf_pos_in_tree
-        for item in merkle_branch_bytes:
-            if len(item) != 32:
+        for sibling in merkle_branch_bytes:
+            if len(sibling) != 32:
                 raise MerkleVerificationFailure('all merkle branch items have to be 32 bytes long')
-            inner_node = (item + h) if (index & 1) else (h + item)
+            is_right_child = (index & 1)
+            inner_node = (sibling + h) if is_right_child else (h + sibling)
+            # CVE-2017-12842 protection: inner node must not be a valid tx
             cls._raise_if_valid_tx(inner_node.hex())
+            # CVE-2012-2459 protection: reject left-sibling duplicates
+            if is_right_child and sibling == h:
+                raise LeftSiblingDuplicate()
             h = sha256d(inner_node)
             index >>= 1
         if index != 0:
@@ -162,7 +168,7 @@ class SPV(NetworkJobOnDefaultServer):
 
     @classmethod
     def _raise_if_valid_tx(cls, raw_tx: str):
-        # If an inner node of the merkle proof is also a valid tx, chances are, this is an attack.
+        # CVE-2017-12842: If an inner node of the merkle proof is also a valid tx, chances are, this is an attack.
         # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-June/016105.html
         # https://lists.linuxfoundation.org/pipermail/bitcoin-dev/attachments/20180609/9f4f5b1f/attachment-0001.pdf
         # https://bitcoin.stackexchange.com/questions/76121/how-is-the-leaf-node-weakness-in-merkle-trees-exploitable/76122#76122

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -3,7 +3,7 @@
 from electrum.bitcoin import hash_encode
 from electrum.transaction import Transaction
 from electrum.util import bfh
-from electrum.verifier import SPV, InnerNodeOfSpvProofIsValidTx
+from electrum.verifier import SPV, InnerNodeOfSpvProofIsValidTx, LeftSiblingDuplicate
 
 from . import ElectrumTestCase
 
@@ -49,3 +49,34 @@ class VerifierTestCase(ElectrumTestCase):
         f_tx_hash = hash_encode(bfh(VALID_64_BYTE_TX[:64]))
         with self.assertRaises(InnerNodeOfSpvProofIsValidTx):
             SPV.hash_merkle_root(fake_mbranch, f_tx_hash, 6)
+
+
+class TestVerifier_CVE_2012_2459(ElectrumTestCase):
+    # These tests are regarding CVE-2012-2459.
+    # Bitcoin's Merkle tree duplicates odd nodes to balance the tree. An attacker can
+    # exploit this by constructing a tree where a duplicated subtree is treated
+    # as containing real leaves, allowing forged proofs for phantom leaf positions.
+    TESTNET = True
+
+    # from testnet3 block 4909055
+    # - block has 3 txns total, so valid indices [0,1,2]
+    # - next power of 2 is 4, so merkle tree leaves are [t0,t1,t2,t2']
+    # - TXID is for t2, so its real index is 2, but index 3 could be forged for it
+    MERKLE_BRANCH = [
+        '9b2c7e407188465594832cfbe84c9758029084527c855ea29a16603e5d1c51b6',
+        'a8484ccbaa74ffa060d0a500f7ce3ea4953beace18df8384024dfa9290385b1c',
+    ]
+    MERKLE_ROOT = '3465af659f6438b133c6d980accbb61b7be43f8ad899e40054e33b37aecba28e'
+    TXID = '9b2c7e407188465594832cfbe84c9758029084527c855ea29a16603e5d1c51b6'
+
+    def test_valid_right_sibling_duplicate(self):
+        leaf_pos_in_tree = 2
+        self.assertEqual(
+            self.MERKLE_ROOT,
+            SPV.hash_merkle_root(self.MERKLE_BRANCH, self.TXID, leaf_pos_in_tree),
+        )
+
+    def test_malicious_left_sibling_duplicate(self):
+        leaf_pos_in_tree = 3
+        with self.assertRaises(LeftSiblingDuplicate):
+            SPV.hash_merkle_root(self.MERKLE_BRANCH, self.TXID, leaf_pos_in_tree)


### PR DESCRIPTION
**Summary**

Backport upstream Electrum’s SPV hardening for CVE-2012-2459 to Electrum-LTC.

Because Bitcoin-style transaction Merkle trees duplicate odd nodes, multiple leaf layouts can produce the same Merkle root. For an SPV client, that means Merkle-root validation alone is not enough to validate a transaction's claimed position in the block.

This patch rejects a duplicated hash when it appears as a left sibling while walking the proof. Legitimate balancing duplicates appear as right siblings, so valid proofs remain accepted.

**Changes**

* Add LeftSiblingDuplicate as a dedicated Merkle verification failure.
* Track whether the current hash is the right child while walking the Merkle proof.
* Reject a proof when a left sibling is identical to the current hash.
* Preserve legitimate right-sibling duplication used to balance odd Merkle-tree levels.
* Add regression tests covering both valid and malicious duplicate cases

Security context / original references

This is a direct backport of the security hardening merged upstream in Electrum:

* Electrum PR #10568: https://github.com/spesmilo/electrum/pull/10568
* Electrum 4.8.0 release notes: https://github.com/spesmilo/electrum/blob/master/RELEASE-NOTES

**Testing**

**Regression coverage is added to tests/test_verifier.py for:**

1. a legitimate right-sibling duplicate, which must continue to verify
2. a forged left-sibling duplicate, which must raise LeftSiblingDuplicate

**Suggested test command:**

python3 -m pytest tests/test_verifier.py -v

**Upstream assessment**

Upstream Electrum described the issue as low severity for Electrum and released the fix in Electrum 4.8.0.

**Credit**

Code adaptation and pull request description prepared with assistance from ChatGPT by OpenAI.