### PR TITLE
Optimize/synchronizer comprehensions

### DIFF
--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -99,7 +99,7 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
 
     async def _on_address_status(self, addr: str, status: Optional[str]):
         """Handle the change of the status of an address.
-        Should remove addr from _handling_addr_statuses when done.
+        Should remove addr from self._handling_addr_statuses when done.
         """
         raise NotImplementedError()  # implemented by subclasses
 

--- a/electrum/synchronizer.py
+++ b/electrum/synchronizer.py
@@ -99,7 +99,7 @@ class SynchronizerBase(NetworkJobOnDefaultServer):
 
     async def _on_address_status(self, addr: str, status: Optional[str]):
         """Handle the change of the status of an address.
-        Should remove addr from self._handling_addr_statuses when done.
+        Should remove addr from _handling_addr_statuses when done.
         """
         raise NotImplementedError()  # implemented by subclasses
 
@@ -196,10 +196,13 @@ class Synchronizer(SynchronizerBase):
         finally:
             self._handling_addr_statuses.discard(addr)
         result = await self._maybe_request_history_for_addr(addr, ann_status=status)
-        hist = list(map(lambda item: (item['tx_hash'], item['height']), result))
+        hist = [(item['tx_hash'], item['height']) for item in result]
         # tx_fees
-        tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
-        tx_fees = dict(filter(lambda x:x[1] is not None, tx_fees))
+        tx_fees = {
+            item['tx_hash']: item['fee']
+            for item in result
+            if item.get('fee') is not None
+        }
         # Check that the status corresponds to what was announced
         if history_status(hist) != status:
             # could happen naturally if history changed between getting status and history (race)


### PR DESCRIPTION
## Summary

Simplify transaction history and fee processing in `electrum/synchronizer.py` by replacing `map(lambda ...)` and `filter(lambda ...)` with direct comprehensions.

The behavior stays the same, but the code avoids unnecessary lambda calls and removes an intermediate fee list.

## Before

```python
hist = list(map(lambda item: (item['tx_hash'], item['height']), result))

tx_fees = [(item['tx_hash'], item.get('fee')) for item in result]
tx_fees = dict(filter(lambda x: x[1] is not None, tx_fees))
```

The fee path effectively does:

```text
result
  ↓
build tuple
  ↓
store tuple in temporary list
  ↓
iterate temporary list again
  ↓
call filter lambda
  ↓
build dictionary
```

## After

```python
hist = [(item['tx_hash'], item['height']) for item in result]

tx_fees = {
    item['tx_hash']: item['fee']
    for item in result
    if item.get('fee') is not None
}
```

The new fee path is:

```text
result
  ↓
inspect item
  ↓
has fee?
  ├─ no  → skip
  └─ yes → add directly to dictionary
```

## Benefits

* removes the `map` lambda used for `hist`
* removes the temporary `(tx_hash, fee)` list
* removes the second pass over that temporary list
* removes the `filter` lambda call for each entry
* builds the final `tx_fees` dictionary directly
* preserves the existing output and filtering behavior
* makes the code simpler and more idiomatic Python

This is intentionally a small, low-risk optimization rather than a larger synchronization redesign.

## Credit

Code adaptation and pull request description prepared with assistance from **ChatGPT by OpenAI**.
